### PR TITLE
Fix README and scripts for KMeans example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,17 @@
-# Distributed PageRank on LiveJournal (Spark + Docker)
+# Distributed KMeans with Spark & Docker
 
-This repo demonstrates how to run PageRank on a 5 GB social-network graph using
-only Docker Compose, **Spark 3.5**, and 256 MiB executors—complete with
-Prometheus / Grafana monitoring.
+This repository demonstrates how to run K-Means clustering with Apache Spark using Docker Compose. Each Spark worker is limited to 256 MiB of memory and metrics are exported to Prometheus with a Grafana dashboard provided.
 
 ## Quick start
 
 ```bash
-git clone https://github.com/you/distributed-pagerank.git
-cd distributed-pagerank
+git clone https://github.com/you/kmeans-distributed.git
+cd kmeans-distributed
 
 docker compose build
 
-./experiments/run_single.sh          # ~7 min on a laptop
-
-./experiments/run_five.sh            # ~2 min on the same laptop
+./experiments/run_single.sh   # single worker
+./experiments/run_five.sh     # 5 workers
 
 open http://localhost:8080   # Spark UI
 open http://localhost:9090   # Prometheus
@@ -24,11 +21,11 @@ open http://localhost:3000   # Grafana (admin/admin)
 ## Repo layout
 
 ```bash
-
 docker/          – container specs & monitoring
-src/             – PageRank driver code
+spark_kmeans.py  – K-Means driver code
+docs/            – additional usage docs
 experiments/     – helper scripts for 1-, 2- & 5-node runs
-results/         – JSON speed-test output + sample screenshots
-For design rationale, performance numbers, and lessons learned, see REPORT.md.
+results/         – JSON timing output
 ```
----
+
+See `docs/USAGE.md` for detailed usage instructions.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,8 @@ version: "3.9"
 
 services:
   spark-master:
-    image: bitnami/spark:latest            # official Bitnami Spark image :contentReference[oaicite:0]{index=0}
+    image: bitnami/spark:latest            # official Bitnami Spark image
+    build: ./docker/spark
     hostname: spark-master
     environment:
       - SPARK_MODE=master
@@ -12,6 +13,7 @@ services:
     volumes:
       - ./docker/spark/spark-env.sh:/opt/bitnami/spark/conf/spark-env.sh
       - ./docker/spark/metrics.properties:/opt/bitnami/spark/conf/metrics.properties
+      - ./docker/spark/config.yaml:/opt/jmx/config.yaml
       - ./src:/opt/spark-apps
       - jmx:/opt/jmx
     ports:
@@ -22,6 +24,7 @@ services:
 
   spark-worker:
     image: bitnami/spark:latest
+    build: ./docker/spark
     depends_on: [spark-master]
     environment:
       - SPARK_MODE=worker
@@ -31,6 +34,7 @@ services:
     volumes:
       - ./docker/spark/spark-env.sh:/opt/bitnami/spark/conf/spark-env.sh
       - ./docker/spark/metrics.properties:/opt/bitnami/spark/conf/metrics.properties
+      - ./docker/spark/config.yaml:/opt/jmx/config.yaml
       - jmx:/opt/jmx
     networks: [snet]
     deploy:

--- a/docker/spark/Dockerfile
+++ b/docker/spark/Dockerfile
@@ -9,6 +9,7 @@ RUN mkdir -p /opt/jmx && \
 
 COPY spark-env.sh            /opt/bitnami/spark/conf/spark-env.sh
 COPY metrics.properties      /opt/bitnami/spark/conf/metrics.properties
+COPY config.yaml             /opt/jmx/config.yaml
 COPY entrypoint.sh           /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 

--- a/docker/spark/config.yaml
+++ b/docker/spark/config.yaml
@@ -1,0 +1,3 @@
+startDelaySeconds: 0
+lowercaseOutputName: true
+lowercaseOutputLabelNames: true

--- a/docker/spark/metrics.properties
+++ b/docker/spark/metrics.properties
@@ -1,0 +1,6 @@
+*.sink.prometheus.class=org.apache.spark.metrics.sink.PrometheusServlet
+*.sink.prometheus.path=/metrics
+master.source.jvm.class=org.apache.spark.metrics.source.JvmSource
+worker.source.jvm.class=org.apache.spark.metrics.source.JvmSource
+driver.source.jvm.class=org.apache.spark.metrics.source.JvmSource
+executor.source.jvm.class=org.apache.spark.metrics.source.JvmSource

--- a/experiments/run_five.sh
+++ b/experiments/run_five.sh
@@ -4,4 +4,4 @@ set -e
 docker compose up -d --build --scale spark-worker=5
 sleep 10
 docker compose exec spark-master \
-  spark-submit /opt/spark-apps/pagerank.py hdfs:///soc-LiveJournal1.txt 10 320
+  spark-submit /opt/spark-apps/spark_kmeans.py --input hdfs:///data/higgs/part-*.csv --k 20

--- a/experiments/run_single.sh
+++ b/experiments/run_single.sh
@@ -4,4 +4,4 @@ set -e
 docker compose up -d --build --scale spark-worker=1
 sleep 10
 docker compose exec spark-master \
-  spark-submit /opt/spark-apps/pagerank.py hdfs:///soc-LiveJournal1.txt 10 64
+  spark-submit /opt/spark-apps/spark_kmeans.py --input hdfs:///data/higgs/part-*.csv --k 20

--- a/experiments/run_two.sh
+++ b/experiments/run_two.sh
@@ -4,4 +4,4 @@ set -e
 docker compose up -d --build --scale spark-worker=2
 sleep 10
 docker compose exec spark-master \
-  spark-submit /opt/spark-apps/pagerank.py hdfs:///soc-LiveJournal1.txt 10 128
+  spark-submit /opt/spark-apps/spark_kmeans.py --input hdfs:///data/higgs/part-*.csv --k 20


### PR DESCRIPTION
## Summary
- update README to reflect KMeans example
- include monitoring config files
- mount config files and build custom spark image in docker-compose
- update Dockerfile to copy config
- update run scripts to call `spark_kmeans.py`

## Testing
- `python -m py_compile spark_kmeans.py src/pagerank.py src/utils.py`
- `bash -n experiments/run_single.sh`
- `bash -n experiments/run_two.sh`
- `bash -n experiments/run_five.sh`
